### PR TITLE
feat(serviceevents): resolve aws.local.environment in the SDK (JS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(serviceevents): resolve `aws.local.environment` in the SDK (eks/k8s/ecs/ec2/generic) to align
+  ServiceEvents & Dynamic Instrumentation with the CloudWatch agent, with a custom EC2 ASG detector
+  ([#503](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/503))
 - feat: support lite mode on ESM handlers and Node.js 24
   ([#502](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/502))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -22,6 +22,8 @@ import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
 import { AWSXRayIdGenerator } from '@opentelemetry/id-generator-aws-xray';
 import { Instrumentation } from '@opentelemetry/instrumentation';
 import { awsEc2Detector, awsEcsDetector, awsEksDetector } from '@opentelemetry/resource-detector-aws';
+import { Ec2AutoScalingGroupDetector } from './serviceevents/utils/ec2-asg-detector';
+import { EcsClusterDetector } from './serviceevents/utils/ecs-cluster-detector';
 import {
   Resource,
   ResourceDetectionConfig,
@@ -125,6 +127,8 @@ interface OtlpLogHeaderSetting {
  */
 export class AwsOpentelemetryConfigurator {
   private resource: Resource;
+  // Global resource + EC2 ASG detector, used by ServiceEvents + DI (see getServiceEventsResource).
+  private serviceEventsResource: Resource;
   private instrumentations: Instrumentation[];
   private idGenerator: IdGenerator;
   private sampler: Sampler;
@@ -184,6 +188,13 @@ export class AwsOpentelemetryConfigurator {
       defaultDetectors.push(envDetector);
     } else {
       // envDetector needs to be last so it can override any conflicting resource attributes.
+      // The Ec2AutoScalingGroupDetector is intentionally NOT in the global detector list, so
+      // ec2.tag.aws:autoscaling:groupName does NOT ride the global resource (which feeds
+      // Application Signals). The CloudWatch agent reads that exact key off incoming telemetry
+      // (awsapplicationsignals processor) and would resolve the AppSignals EC2 environment from
+      // our SDK-sent value — so keeping it off the global resource avoids changing AppSignals'
+      // environment (ServiceEvents/DI-only scope). The ASG is instead folded into the dedicated
+      // ServiceEvents resource below.
       defaultDetectors = [processDetector, hostDetector, awsEc2Detector, awsEcsDetector, awsEksDetector, envDetector];
     }
 
@@ -193,6 +204,24 @@ export class AwsOpentelemetryConfigurator {
 
     autoResource = this.customizeResource(autoResource.merge(detectResources(internalConfig)));
     this.resource = autoResource;
+
+    // ServiceEvents + DI get their OWN resource, which is the global resource PLUS the EC2 ASG
+    // detector. This keeps ec2.tag.aws:autoscaling:groupName off the global/AppSignals resource
+    // (see note above) while still letting the SDK resolver compute ec2:<asg>. Off-EC2 the ASG
+    // detector contributes nothing, so this equals the global resource.
+    if (isLambdaEnvironment() || isAgentObservabilityEnabled()) {
+      this.serviceEventsResource = this.resource;
+    } else {
+      // Ec2AutoScalingGroupDetector: ASG tag for ec2:<asg> (kept off the global resource).
+      // EcsClusterDetector: ECS cluster ARN for ecs:<cluster> — works around the upstream
+      // AwsEcsDetector bug (it returns attributes as a single Promise, which ResourceImpl
+      // drops via Object.entries(), so aws.ecs.cluster.arn never lands). Off-platform both
+      // contribute nothing, so this equals the global resource.
+      const seDetectorConfig: ResourceDetectionConfig = {
+        detectors: [new Ec2AutoScalingGroupDetector(), new EcsClusterDetector()],
+      };
+      this.serviceEventsResource = this.resource.merge(detectResources(seDetectorConfig));
+    }
 
     this.instrumentations = instrumentations;
     this.propagator = getPropagator();
@@ -267,6 +296,13 @@ export class AwsOpentelemetryConfigurator {
     }
 
     return config;
+  }
+
+  // Resource for ServiceEvents + DI (global resource + EC2 ASG detector). Kept separate from
+  // configure().resource so the ASG tag stays off the global/AppSignals resource. See the
+  // constructor note.
+  public getServiceEventsResource(): Resource {
+    return this.serviceEventsResource;
   }
 
   static isApplicationSignalsEnabled(): boolean {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/client.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/client.ts
@@ -19,10 +19,23 @@ import { DI_USER_AGENT, DEFAULT_HTTP_TIMEOUT_MS, MAX_PAGES_PER_FETCH } from './m
 export class DynamicInstrumentationClient {
   private readonly apiUrl: string;
   private readonly timeoutMs: number;
+  private readonly namespace: string;
+  private readonly environment: string;
 
-  constructor(apiUrl: string, timeoutMs: number = DEFAULT_HTTP_TIMEOUT_MS) {
+  constructor(
+    apiUrl: string,
+    timeoutMs: number = DEFAULT_HTTP_TIMEOUT_MS,
+    namespace: string = '',
+    environment: string = ''
+  ) {
     this.apiUrl = apiUrl.replace(/\/+$/, ''); // strip trailing slashes
     this.timeoutMs = timeoutMs;
+    // Pod-owned environment inputs forwarded to the CloudWatch agent proxy so it can
+    // resolve the same aws.local.environment Application Signals uses. The agent
+    // cannot derive these itself: the namespace and an explicit deployment environment
+    // are properties of the calling pod, not the agent.
+    this.namespace = namespace;
+    this.environment = environment;
   }
 
   /**
@@ -98,17 +111,28 @@ export class DynamicInstrumentationClient {
         const transport = isHttps ? https : http;
 
         const data = JSON.stringify(body);
+        const headers: Record<string, string | number> = {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data),
+          'User-Agent': DI_USER_AGENT,
+        };
+        // Forward the pod-owned environment inputs so the CloudWatch agent proxy can
+        // resolve the deployment environment (eks:<cluster>/<namespace>, or an explicit
+        // value) and inject it as the request's Environment lookup key. Only sent when
+        // present, so non-K8s / no-explicit-env deployments are unaffected.
+        if (this.namespace) {
+          headers['X-Aws-K8s-Namespace'] = this.namespace;
+        }
+        if (this.environment) {
+          headers['X-Aws-Deployment-Environment'] = this.environment;
+        }
         const options: http.RequestOptions = {
           method: 'POST',
           hostname: url.hostname,
           port: url.port || (isHttps ? 443 : 80),
           path: url.pathname,
           timeout: this.timeoutMs,
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': Buffer.byteLength(data),
-            'User-Agent': DI_USER_AGENT,
-          },
+          headers,
         };
 
         const req = transport.request(options, res => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/config.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/config.ts
@@ -20,6 +20,10 @@ export interface DynamicInstrumentationConfig {
   logsEndpoint: string;
   serviceName: string;
   environment: string;
+  // Kubernetes namespace (from OTEL_RESOURCE_ATTRIBUTES[k8s.namespace.name]). Sent to
+  // the CloudWatch agent proxy so it can resolve the same aws.local.environment
+  // (eks:<cluster>/<namespace>) that Application Signals uses. Empty when not on K8s.
+  namespace: string;
   /**
    * Resource attributes (string-valued) from the OTel SDK Resource, used to
    * evaluate AttributeFilters on instrumentation configurations. Populated by
@@ -119,6 +123,25 @@ function resolveEnvironment(): string {
 }
 
 /**
+ * Extract k8s.namespace.name from OTEL_RESOURCE_ATTRIBUTES (injected by the
+ * CloudWatch Agent Operator on EKS). Sent to the agent proxy so it can resolve the
+ * workload's deployment environment; the agent cannot know the caller pod's
+ * namespace on its own.
+ */
+function resolveNamespace(): string {
+  const envResources = process.env.OTEL_RESOURCE_ATTRIBUTES ?? '';
+  for (const pair of envResources.split(',')) {
+    if (pair.includes('=')) {
+      const [key, ...rest] = pair.split('=');
+      if (key.trim() === 'k8s.namespace.name') {
+        return rest.join('=').trim();
+      }
+    }
+  }
+  return '';
+}
+
+/**
  * Create DI config from environment variables.
  */
 export function createDynamicInstrumentationConfig(): DynamicInstrumentationConfig {
@@ -141,6 +164,7 @@ export function createDynamicInstrumentationConfig(): DynamicInstrumentationConf
     logsEndpoint: getEnvStr('OTEL_AWS_OTLP_LOGS_ENDPOINT', 'http://localhost:4316/v1/logs'),
     serviceName: resolveServiceName(),
     environment: resolveEnvironment(),
+    namespace: resolveNamespace(),
     resourceAttributes: {},
   };
 }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/index.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/index.ts
@@ -7,6 +7,7 @@ import { Worker } from 'worker_threads';
 import { diag } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { createDynamicInstrumentationConfig, DynamicInstrumentationConfig } from './config';
+import { resolveLocalEnvironment } from '../serviceevents/utils/environment-resolver';
 
 // Max time to wait for async resource detectors (EC2/ECS/EKS, etc.) to resolve
 // before reading resource attributes for attribute-filter evaluation.
@@ -72,6 +73,16 @@ export class DynamicInstrumentationManager {
       }
 
       this.config.resourceAttributes = await resolveResourceAttributes(resource);
+
+      // SDK-only environment resolution: compute aws.local.environment from the detected
+      // resource attributes using the same precedence as the CloudWatch agent, and use it
+      // as the DI request's Environment lookup key. This makes DI self-sufficient (no
+      // dependency on the agent proxy injecting the environment). An explicit
+      // deployment.environment[.name] still wins via the resolver's precedence.
+      const resolvedEnv = resolveLocalEnvironment({ attributes: this.config.resourceAttributes });
+      if (resolvedEnv) {
+        this.config.environment = resolvedEnv;
+      }
 
       this.spawnWorker();
       this.initialized = true;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/index.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/index.ts
@@ -79,7 +79,7 @@ export class DynamicInstrumentationManager {
       // as the DI request's Environment lookup key. This makes DI self-sufficient (no
       // dependency on the agent proxy injecting the environment). An explicit
       // deployment.environment[.name] still wins via the resolver's precedence.
-      const resolvedEnv = resolveLocalEnvironment({ attributes: this.config.resourceAttributes });
+      const resolvedEnv = resolveLocalEnvironment(this.config.resourceAttributes);
       if (resolvedEnv) {
         this.config.environment = resolvedEnv;
       }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/worker.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/worker.ts
@@ -47,7 +47,7 @@ let exiting: boolean = false;
  */
 async function initialize(): Promise<void> {
   try {
-    const client = new DynamicInstrumentationClient(config.apiUrl);
+    const client = new DynamicInstrumentationClient(config.apiUrl, undefined, config.namespace, config.environment);
     const sourceMapResolver = new SourceMapResolver();
     const fileResolver = new FileResolver();
     fileResolver.setSourceMapResolver(sourceMapResolver);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -274,10 +274,11 @@ try {
   diag.debug(`Environment variable OTEL_EXPORTER_OTLP_PROTOCOL is set to '${process.env.OTEL_EXPORTER_OTLP_PROTOCOL}'`);
   diag.info('AWS Distro of OpenTelemetry automatic instrumentation started successfully');
 
-  // Pass the configured SDK Resource so DI can evaluate AttributeFilters against
-  // the application's real resource attributes (service.name, deployment.environment,
-  // and detector-contributed attributes such as cloud.region, host.name, etc.).
-  initializeDynamicInstrumentation(process.env, configuration.resource);
+  // Pass the ServiceEvents resource (global resource + EC2 ASG detector) so DI can both
+  // evaluate AttributeFilters AND resolve aws.local.environment to ec2:<asg> on EC2.
+  // This resource carries the ASG tag that is intentionally kept off the global resource;
+  // off-EC2 it equals configuration.resource.
+  initializeDynamicInstrumentation(process.env, configurator.getServiceEventsResource());
 
   // Initialize ServiceEvents deep observability instrumentation (main thread only).
   // When the DI manager spawns a Worker, Node re-runs `--require register` inside
@@ -298,7 +299,13 @@ try {
       // config.enabled mirrors OTEL_AWS_SERVICE_EVENTS_ENABLED directly; the outer
       // bundling gate above has already decided ServiceEvents should run, so flip
       // the inner flag on regardless of whether the env var was set.
-      const serviceeventsConfig = { ...createServiceEventsConfigFromEnv(), enabled: true };
+      const serviceeventsConfig = {
+        ...createServiceEventsConfigFromEnv(),
+        enabled: true,
+        // ServiceEvents resource (global + EC2 ASG detector); off-EC2 equals
+        // configuration.resource. Keeps the ASG tag off the global/AppSignals resource.
+        detectedResource: configurator.getServiceEventsResource(),
+      };
       const serviceevents = getServiceEventsInstrumentation(serviceeventsConfig);
       if (serviceevents) {
         serviceevents.initialize();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/deployment-event-collector.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/deployment-event-collector.ts
@@ -7,6 +7,9 @@ import { ServiceEventsOtlpEmitter } from '../exporter/otlp-emitter';
 
 export class DeploymentEventCollector extends BaseCollector {
   private otlpEmitter: ServiceEventsOtlpEmitter | null;
+  // Guarantees the startup DeploymentEvent is emitted exactly once. Mirrors Python's
+  // `_first_collect` / Java's `firstCollect` flag.
+  private startupEmitted: boolean = false;
 
   constructor(flushIntervalMs: number, otlpEmitter: ServiceEventsOtlpEmitter | null) {
     super(flushIntervalMs, 'DeploymentEventCollector');
@@ -14,19 +17,44 @@ export class DeploymentEventCollector extends BaseCollector {
   }
 
   override start(): void {
-    if (this.otlpEmitter) {
-      try {
-        this.otlpEmitter.emitDeploymentEvent('startup');
-        diag.info('Emitted DeploymentEvent (trigger=startup)');
-      } catch (err) {
-        diag.error(`Error in startup DeploymentEvent emit: ${err}`);
-      }
-    }
     super.start();
+    if (this.otlpEmitter) {
+      // Defer the startup emit until the emitter's async resource has settled. Emitting
+      // synchronously here (as before) raced the emitter constructor's async-attribute
+      // resolution: ensureInitialized() gates on asyncResourceReady and silently no-ops the
+      // emit (there is NO pre-init buffer — the record is dropped, not queued), so the
+      // startup DeploymentEvent never reached the backend. whenReady() always resolves
+      // (the constructor races a 2s timeout), so this fires within ~2s of startup, well
+      // before the first periodic tick. Both arms call emitStartupOnce so even an unexpected
+      // rejection still emits; the guard makes it idempotent.
+      this.otlpEmitter.whenReady().then(
+        () => this.emitStartupOnce(),
+        () => this.emitStartupOnce()
+      );
+    }
+  }
+
+  /** Emit the startup DeploymentEvent exactly once (idempotent). */
+  private emitStartupOnce(): void {
+    if (this.startupEmitted || !this.otlpEmitter) return;
+    this.startupEmitted = true;
+    try {
+      this.otlpEmitter.emitDeploymentEvent('startup');
+      diag.info('Emitted DeploymentEvent (trigger=startup)');
+    } catch (err) {
+      diag.error(`Error in startup DeploymentEvent emit: ${err}`);
+    }
   }
 
   collect(): void {
     if (!this.otlpEmitter) return;
+    // Fallback guarantee: if the deferred startup emit hasn't fired yet (e.g. a very fast
+    // shutdown before whenReady() resolved), label this first-ever emit "startup" rather
+    // than losing the marker — matching Python/Java's first-collect-is-startup semantics.
+    if (!this.startupEmitted) {
+      this.emitStartupOnce();
+      return;
+    }
     const trigger = this.isRunning() ? 'periodic' : 'shutdown';
     try {
       this.otlpEmitter.emitDeploymentEvent(trigger);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/config.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/config.ts
@@ -140,8 +140,14 @@ export interface ServiceEventsConfig {
   // EndpointMetricCollector still runs so latency histograms feed
   // IncidentSnapshot thresholds. Per-exception-type error metrics still emit.
   applicationSignalsEnabled: boolean; // OTEL_AWS_APPLICATION_SIGNALS_ENABLED
-  // Resource attributes from OTel resource
+  // Resource attributes from OTel resource (env-var parsed subset for EMF dimensions)
   resourceAttributes: ResourceAttributes;
+  // The fully-detected OTel Resource from the configurator (includes all cloud/host/k8s
+  // attributes from resource detectors). When available, the emitter uses this as the
+  // base resource — enabling the SDK-side environment resolver to compute
+  // aws.local.environment with the same inputs the agent would have. Undefined when
+  // the SDK Resource is not yet available at config time.
+  detectedResource?: { attributes: Record<string, unknown> };
 }
 
 /** Default configuration values. */

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/exporter/otlp-emitter.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/exporter/otlp-emitter.ts
@@ -39,6 +39,8 @@ import { EndpointMetricEvent, EndpointErrorMetric } from '../models/endpoint-tel
 import { FunctionCallMetrics, DurationMetrics } from '../models/function-telemetry';
 import { IncidentSnapshot } from '../models/incident-telemetry';
 import { DeploymentContext } from '../models/deployment-telemetry';
+import { ResourceAttributes } from '../models/resource-attributes';
+import { stampLocalEnvironment } from '../utils/environment-resolver';
 import {
   ServiceEventsCloudWatchLogFileExporter,
   ServiceEventsCloudWatchMetricFileExporter,
@@ -47,6 +49,12 @@ import { wrapExporterSuppressed } from './suppressed-exporter';
 
 const INSTRUMENTATION_SCOPE = 'serviceevents';
 const INSTRUMENTATION_VERSION = '1.0';
+
+// Max time to wait for the detected resource's async attributes (ECS/EC2/EKS detectors) to
+// settle before ServiceEvents initializes anyway. A hung/blocked detector (e.g. IMDS
+// unreachable) must never permanently disable ServiceEvents — after this we proceed with
+// whatever resolved. Mirrors DI's RESOURCE_ATTRIBUTES_TIMEOUT_MS.
+const ASYNC_ATTRIBUTES_TIMEOUT_MS = 2000;
 
 const EVENT_NAME_ENDPOINT_SUMMARY = 'aws.service_events.endpoint_summary';
 const EVENT_NAME_FUNCTION_CALL = 'aws.service_events.function_call';
@@ -62,6 +70,30 @@ export interface ServiceEventsOtlpEmitterOptions {
    * and isn't repeated on every per-call attribute set.
    */
   sdkVersion?: string;
+  /**
+   * Cloud/host/k8s resource attributes detected from `OTEL_RESOURCE_ATTRIBUTES`
+   * (e.g. `k8s.namespace.name`, `k8s.cluster.name`, `cloud.*`). Folded onto the
+   * OTel Resource of every ServiceEvents signal so the CloudWatch agent's
+   * Application Signals resolver computes the SAME `aws.local.environment`
+   * (e.g. `eks:<cluster>/<namespace>`) it computes for App Signals telemetry —
+   * without these, the resolver falls back to `UnknownNamespace` and the two
+   * signals fail to correlate.
+   */
+  resourceAttributes?: ResourceAttributes;
+  // The fully-detected OTel Resource (from the configurator). When provided, the emitter
+  // uses this as the resource base and computes aws.local.environment locally — enabling
+  // the SDK-only environment-alignment approach (no CWAgent dependency for env resolution).
+  //
+  // IMPORTANT: this is the LIVE Resource (not a flattened attribute snapshot). The AWS
+  // resource detectors (ECS/EC2/EKS) are ASYNC in JS, so `resource.attributes` is empty of
+  // their values until `waitForAsyncAttributes()` has resolved. The emitter awaits that
+  // (kicked off in the constructor) before snapshotting, so aws.ecs.cluster.arn / the ASG
+  // tag / cloud.platform are present when the resolver runs — matching what AppSignals/DI do.
+  detectedResource?: {
+    attributes: Record<string, unknown>;
+    asyncAttributesPending?: boolean;
+    waitForAsyncAttributes?: () => Promise<void>;
+  };
   logsEndpoint?: string;
   metricsEndpoint?: string;
   /**
@@ -109,6 +141,23 @@ export class ServiceEventsOtlpEmitter {
   private readonly serviceName: string;
   private readonly environment?: string;
   private readonly sdkVersion: string;
+  private readonly resourceAttributes: ResourceAttributes;
+  private readonly detectedResource?: {
+    attributes: Record<string, unknown>;
+    asyncAttributesPending?: boolean;
+    waitForAsyncAttributes?: () => Promise<void>;
+  };
+  // True once the detected resource's async attributes (ECS/EC2/EKS detectors) have settled
+  // — or there were none to wait for. ensureInitialized() defers until this is true so the
+  // resolver sees aws.ecs.cluster.arn / ASG tag / cloud.platform.
+  private asyncResourceReady: boolean = false;
+  // Resolves when asyncResourceReady becomes true. Lets callers (e.g. the
+  // DeploymentEventCollector's startup emit) defer until the emitter can actually initialize,
+  // instead of firing synchronously during construction and being silently dropped by
+  // ensureInitialized()'s readiness gate. Always settles — the constructor races detector
+  // resolution against a 2s timeout, so this never hangs.
+  private readonly readyPromise: Promise<void>;
+  private resolveReady!: () => void;
   private readonly logsEndpoint: string;
   private readonly metricsEndpoint: string;
   private readonly outputFile: string;
@@ -118,11 +167,44 @@ export class ServiceEventsOtlpEmitter {
   private readonly logStream: string;
 
   constructor(opts: ServiceEventsOtlpEmitterOptions = {}) {
+    // Set up the readiness promise first so the resolver is available to the branches below.
+    this.readyPromise = new Promise<void>(resolve => {
+      this.resolveReady = resolve;
+    });
     this.serviceName = opts.serviceName ?? 'UnknownService';
     // No sentinel: when environment is unset it stays undefined and the
     // deployment.environment resource attribute / environment dimension are omitted.
     this.environment = opts.environment;
     this.sdkVersion = opts.sdkVersion ?? '';
+    this.resourceAttributes = opts.resourceAttributes ?? new ResourceAttributes();
+    this.detectedResource = opts.detectedResource;
+    // Kick off async-attribute resolution now (fire-and-forget). The AWS detectors are
+    // async; without awaiting waitForAsyncAttributes() the resource's .attributes never
+    // gains the ECS/EC2/EKS values (asyncAttributesPending stays true forever), so the
+    // resolver would wrongly fall through to ec2:default. First emit happens on a request,
+    // well after this resolves. Mirrors DI's resolveResourceAttributes() and AppSignals.
+    const dr = this.detectedResource;
+    if (dr && dr.asyncAttributesPending && typeof dr.waitForAsyncAttributes === 'function') {
+      // Race the detector resolution against a timeout: a hung/slow detector (e.g. an IMDS
+      // call when IMDS is blocked) must NEVER permanently gate ServiceEvents off. After the
+      // timeout we proceed with whatever attributes have resolved so far — same safety
+      // pattern as Dynamic Instrumentation's resolveResourceAttributes().
+      const waitWithCatch = dr.waitForAsyncAttributes().catch(() => {
+        // A detector rejecting must not break ServiceEvents — proceed with what resolved.
+      });
+      const timeout = new Promise<void>(resolve => {
+        const timer = setTimeout(resolve, ASYNC_ATTRIBUTES_TIMEOUT_MS);
+        // Don't keep the event loop alive solely for this timer.
+        if (typeof timer.unref === 'function') timer.unref();
+      });
+      Promise.race([waitWithCatch, timeout]).finally(() => {
+        this.asyncResourceReady = true;
+        this.resolveReady();
+      });
+    } else {
+      this.asyncResourceReady = true;
+      this.resolveReady();
+    }
     this.outputFile = opts.outputFile ?? process.env.OTEL_AWS_SERVICE_EVENTS_OUTPUT_FILE ?? '';
     this.logsEndpoint = resolveLogsEndpoint(opts.logsEndpoint);
     this.metricsEndpoint = resolveMetricsEndpoint(opts.metricsEndpoint);
@@ -146,6 +228,17 @@ export class ServiceEventsOtlpEmitter {
   }
 
   /**
+   * Resolves once the emitter is ready to initialize — i.e. the detected resource's async
+   * attributes have settled (or the 2s timeout elapsed, or there were none to wait for).
+   * Callers that emit at startup (the DeploymentEventCollector) await this so their first
+   * emit isn't silently dropped by ensureInitialized()'s readiness gate. Resolves immediately
+   * if already ready. Never rejects and never hangs (the constructor races a 2s timeout).
+   */
+  whenReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  /**
    * Return the OTel `service.function.duration` Histogram instrument once
    * the emitter has been initialized. Returns null in `output_file` mode,
    * before the first emit triggers initialization, or if init has failed.
@@ -164,6 +257,12 @@ export class ServiceEventsOtlpEmitter {
   private ensureInitialized(): boolean {
     if (this.logger && this.errorCounter) return true;
     if (this.initFailed) return false;
+    // Defer init until the detected resource's async attributes have settled, so the
+    // environment resolver sees the ECS/EC2/EKS attributes (otherwise it falls through to
+    // ec2:default). The very first emit may no-op; a subsequent one (the SE collectors emit
+    // on intervals + per request) initializes once ready. Only gates when there is a live
+    // resource with pending async attributes.
+    if (!this.asyncResourceReady) return false;
 
     try {
       // aws.local.service duplicates service.name for backend compatibility —
@@ -199,13 +298,26 @@ export class ServiceEventsOtlpEmitter {
         resourceAttrs['vcs.repository.url.full'] = this.deploymentContext.git_repo_url;
       }
 
-      // Merge onto the OTel default resource so SDK-identity attributes
-      // (`telemetry.sdk.language` / `.name` / `.version`) flow with every signal —
-      // resourceFromAttributes() alone does NOT include them. Our explicit attrs win
-      // over the default (merge spec: incoming overrides existing), so the placeholder
-      // `service.name` from defaultResource() is replaced by ours. Mirrors Python
-      // (Resource.create merges the default) and Java (uses the autoconfigured resource).
-      const resource = defaultResource().merge(resourceFromAttributes(resourceAttrs));
+      // Build the OTel Resource for ServiceEvents signals. When the fully-detected
+      // resource from the configurator is available, use it directly as
+      // the base — it carries all cloud/host/k8s attributes the environment resolver
+      // needs (k8s.cluster.name, k8s.namespace.name, cloud.platform, ec2 ASG tag, etc.).
+      // Explicit SE attrs are merged LAST so customer-set deployment.environment[.name]
+      // wins (backwards compatible). The SDK-side resolver then computes
+      // aws.local.environment with the same precedence the agent would use.
+      //
+      // When detectedResource is unavailable, falls back to the env-var-parsed path.
+      const baseResource = this.detectedResource
+        ? resourceFromAttributes(this.detectedResource.attributes as Record<string, string>)
+        : defaultResource().merge(resourceFromAttributes(this.resourceAttributes.toDict()));
+
+      const resource = baseResource.merge(resourceFromAttributes(resourceAttrs));
+
+      // SDK-only environment resolution: compute aws.local.environment from the
+      // final resource attributes and stamp it, matching the agent's resolver precedence.
+      const resolvedAttrs = { ...resource.attributes } as Record<string, string>;
+      stampLocalEnvironment(resolvedAttrs);
+      const finalResource = resource.merge(resourceFromAttributes(resolvedAttrs));
 
       const useFile = !!this.outputFile;
 
@@ -214,7 +326,7 @@ export class ServiceEventsOtlpEmitter {
           ? new ServiceEventsCloudWatchLogFileExporter(this.outputFile)
           : wrapExporterSuppressed(this.buildLogOtlpExporter(CompressionAlgorithm.NONE));
         this.loggerProvider = new LoggerProvider({
-          resource,
+          resource: finalResource,
           processors: [new BatchLogRecordProcessor(logExporter)],
         });
       }
@@ -239,7 +351,7 @@ export class ServiceEventsOtlpEmitter {
               })
             );
         this.meterProvider = new MeterProvider({
-          resource,
+          resource: finalResource,
           readers: [
             new PeriodicExportingMetricReader({
               exporter: metricExporter,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/serviceevents-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/serviceevents-instrumentation.ts
@@ -173,6 +173,12 @@ export class ServiceEventsInstrumentation {
         serviceName: this.config.serviceName,
         environment: this.config.environment,
         sdkVersion: this.config.sdkVersion,
+        // Cloud/host/k8s resource attributes (e.g. k8s.namespace.name) so the
+        // CloudWatch agent resolves the same aws.local.environment as App Signals.
+        resourceAttributes: this.config.resourceAttributes,
+        // Fully-detected OTel Resource: when present, the emitter resolves
+        // aws.local.environment itself from this resource, no CWAgent dependency.
+        detectedResource: this.config.detectedResource,
         outputFile: this.config.outputFile,
         logGroup: this.config.logGroup,
         logStream: this.config.logStream,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/ec2-asg-detector.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/ec2-asg-detector.ts
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Resource detector that fetches the EC2 Auto Scaling group name from IMDS instance
+ * tags and exposes it as `ec2.tag.aws:autoscaling:groupName`.
+ *
+ * The stock `@opentelemetry/resource-detector-aws` EC2 detector only reads the
+ * instance-identity document — it does NOT fetch instance tags, so the ASG is absent
+ * from the SDK Resource. The CloudWatch agent, by contrast, reads the ASG from IMDS
+ * instance tags (`/latest/meta-data/tags/instance/aws:autoscaling:groupName`) and uses
+ * it to resolve `ec2:<asg>`. This detector closes that gap so the SDK can compute the
+ * same `aws.local.environment` the agent would on EC2 — without depending on the agent.
+ *
+ * Mirrors the agent's mechanism (amazon-cloudwatch-agent serviceprovider
+ * `scrapeImdsServiceNameAndASG` + ec2tagger `Ec2InstanceTagKeyASG`): IMDSv2 token,
+ * then read the instance tag. Instance metadata tags must be enabled on the instance
+ * (`InstanceMetadataTags=enabled`); when they aren't, the detector returns nothing and
+ * the resolver falls back to `ec2:default` — matching the agent's behavior.
+ */
+
+import { diag } from '@opentelemetry/api';
+import { DetectedResource, ResourceDetector } from '@opentelemetry/resources';
+import * as http from 'http';
+
+const IMDS_HOST = '169.254.169.254';
+const TOKEN_PATH = '/latest/api/token';
+const ASG_TAG_PATH = '/latest/meta-data/tags/instance/aws:autoscaling:groupName';
+const TOKEN_TTL_HEADER = 'X-aws-ec2-metadata-token-ttl-seconds';
+const TOKEN_HEADER = 'X-aws-ec2-metadata-token';
+const TIMEOUT_MS = 1000;
+
+/** The resource attribute key the environment resolver reads — matches the agent's. */
+export const EC2_ASG_ATTRIBUTE = 'ec2.tag.aws:autoscaling:groupName';
+
+/**
+ * Detects the EC2 Auto Scaling group via IMDS instance tags. Resolves to an empty
+ * Resource (no error) when not on EC2 or when instance tags are unavailable.
+ */
+export class Ec2AutoScalingGroupDetector implements ResourceDetector {
+  // IMDS host:port. Overridable for tests; defaults to the EC2 link-local address.
+  private readonly imdsHost: string;
+
+  constructor(imdsHost: string = IMDS_HOST) {
+    this.imdsHost = imdsHost;
+  }
+
+  detect(): DetectedResource {
+    // Attribute values may be Promises in resources 2.x; the SDK awaits them when the
+    // Resource is materialized. Returning undefined (on non-EC2 / no tags) omits the key.
+    return {
+      attributes: {
+        [EC2_ASG_ATTRIBUTE]: this._fetchAsg(),
+      },
+    };
+  }
+
+  private async _fetchAsg(): Promise<string | undefined> {
+    try {
+      const token = await this._fetchToken();
+      const asg = await this._fetchString({
+        ...this._hostPort(),
+        path: ASG_TAG_PATH,
+        method: 'GET',
+        timeout: TIMEOUT_MS,
+        headers: { [TOKEN_HEADER]: token },
+      });
+      const trimmed = asg.trim();
+      return trimmed || undefined;
+    } catch (e) {
+      // Not on EC2, IMDS unreachable, or instance tags not enabled — all expected,
+      // non-fatal. The resolver falls back to ec2:default, matching the agent.
+      diag.debug('Ec2AutoScalingGroupDetector: ASG not available via IMDS instance tags', e);
+      return undefined;
+    }
+  }
+
+  private async _fetchToken(): Promise<string> {
+    return this._fetchString({
+      ...this._hostPort(),
+      path: TOKEN_PATH,
+      method: 'PUT',
+      timeout: TIMEOUT_MS,
+      headers: { [TOKEN_TTL_HEADER]: '60' },
+    });
+  }
+
+  /** Split the configured IMDS host into { host, port } for http.request. */
+  private _hostPort(): { host: string; port?: number } {
+    const idx = this.imdsHost.lastIndexOf(':');
+    if (idx > 0) {
+      return { host: this.imdsHost.slice(0, idx), port: Number(this.imdsHost.slice(idx + 1)) };
+    }
+    return { host: this.imdsHost };
+  }
+
+  private _fetchString(options: http.RequestOptions): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        req.abort();
+        reject(new Error('IMDS request timed out'));
+      }, TIMEOUT_MS);
+      const req = http.request(options, res => {
+        clearTimeout(timeoutId);
+        const statusCode = res.statusCode ?? 0;
+        res.setEncoding('utf8');
+        let raw = '';
+        res.on('data', chunk => (raw += chunk));
+        res.on('end', () => {
+          if (statusCode >= 200 && statusCode < 300) {
+            resolve(raw);
+          } else {
+            reject(new Error(`IMDS request failed with status ${statusCode}`));
+          }
+        });
+      });
+      req.on('error', err => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
+      req.end();
+    });
+  }
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/ecs-cluster-detector.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/ecs-cluster-detector.ts
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Resource detector that fetches the ECS cluster ARN from the ECS task metadata endpoint
+ * and exposes it as `aws.ecs.cluster.arn` (+ `cloud.platform=aws_ecs`).
+ *
+ * Why this exists: the stock `@opentelemetry/resource-detector-aws` AwsEcsDetector
+ * (2.19.0) returns its result as `{ attributes: Promise<{...}> }` — i.e. `attributes` is a
+ * single Promise of the whole object. The `@opentelemetry/resources` (2.x) DetectedResource
+ * contract instead expects `attributes` to be an OBJECT whose VALUES may be promises
+ * (per-key). `ResourceImpl` does `Object.entries(attributes)`, and `Object.entries(promise)`
+ * is `[]` — so the ECS detector's attributes silently never enter the SDK Resource, and
+ * `aws.ecs.cluster.arn` is absent. ServiceEvents then resolves `ec2:default` on ECS instead
+ * of `ecs:<cluster>`. (EC2/EKS detectors use the correct per-key shape and are unaffected.)
+ *
+ * This detector reads the SAME source the agent + AwsEcsDetector use
+ * (`$ECS_CONTAINER_METADATA_URI_V4/task` → `Cluster`) but returns per-key promises, so the
+ * cluster ARN actually lands on the Resource and the environment resolver can compute
+ * `ecs:<cluster>` matching the CloudWatch agent.
+ */
+
+import { diag } from '@opentelemetry/api';
+import { DetectedResource, ResourceDetector } from '@opentelemetry/resources';
+import * as http from 'http';
+
+const TIMEOUT_MS = 1000;
+const AWS_ECS_CLUSTER_ARN = 'aws.ecs.cluster.arn';
+const CLOUD_PLATFORM = 'cloud.platform';
+
+/**
+ * Detects the ECS cluster ARN from the task metadata v4 endpoint. Resolves to an empty
+ * Resource (no error) when not on ECS or when the endpoint is unavailable.
+ */
+export class EcsClusterDetector implements ResourceDetector {
+  // Overridable for tests; defaults to the ECS task metadata v4 endpoint from the
+  // ECS_CONTAINER_METADATA_URI_V4 env var the ECS agent injects into every container.
+  private readonly metadataUriV4?: string;
+
+  constructor(metadataUriV4: string | undefined = process.env.ECS_CONTAINER_METADATA_URI_V4) {
+    this.metadataUriV4 = metadataUriV4;
+  }
+
+  detect(): DetectedResource {
+    // Not on ECS (no metadata endpoint) → contribute nothing.
+    if (!this.metadataUriV4) {
+      return { attributes: {} };
+    }
+    // Per-key promises (the correct DetectedResource shape). The SDK awaits these when the
+    // Resource is materialized (and our SE emitter awaits waitForAsyncAttributes()).
+    const clusterArn = this._fetchClusterArn();
+    return {
+      attributes: {
+        [AWS_ECS_CLUSTER_ARN]: clusterArn,
+        // Only claim the ECS platform once we've confirmed the cluster ARN resolved, so we
+        // don't mislabel a non-ECS host. undefined omits the key.
+        [CLOUD_PLATFORM]: clusterArn.then(arn => (arn ? 'aws_ecs' : undefined)),
+      },
+    };
+  }
+
+  private async _fetchClusterArn(): Promise<string | undefined> {
+    try {
+      const body = await this._fetchString(`${this.metadataUriV4}/task`);
+      const task = JSON.parse(body) as { Cluster?: string; TaskARN?: string };
+      const cluster = (task.Cluster ?? '').trim();
+      if (!cluster) {
+        return undefined;
+      }
+      // `Cluster` may be a bare name or a full ARN. When it's a bare name, derive the ARN
+      // from the task ARN (same as AwsEcsDetector), so the value matches the agent's.
+      if (cluster.startsWith('arn:')) {
+        return cluster;
+      }
+      const taskArn = task.TaskARN ?? '';
+      const baseArn = taskArn.slice(0, taskArn.lastIndexOf(':'));
+      return baseArn ? `${baseArn}:cluster/${cluster}` : cluster;
+    } catch (e) {
+      // Not on ECS, endpoint unreachable, or malformed body — all expected, non-fatal.
+      diag.debug('EcsClusterDetector: ECS cluster ARN not available from task metadata', e);
+      return undefined;
+    }
+  }
+
+  private _fetchString(url: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        req.abort();
+        reject(new Error('ECS metadata request timed out'));
+      }, TIMEOUT_MS);
+      const req = http.get(url, { timeout: TIMEOUT_MS }, res => {
+        clearTimeout(timeoutId);
+        const statusCode = res.statusCode ?? 0;
+        res.setEncoding('utf8');
+        let raw = '';
+        res.on('data', chunk => (raw += chunk));
+        res.on('end', () => {
+          if (statusCode >= 200 && statusCode < 300) {
+            resolve(raw);
+          } else {
+            reject(new Error(`ECS metadata request failed with status ${statusCode}`));
+          }
+        });
+      });
+      req.on('error', err => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
+    });
+  }
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/environment-resolver.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/environment-resolver.ts
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Resolves `aws.local.environment` from OTel Resource attributes using the same
+ * precedence as the CloudWatch agent's awsapplicationsignals processor:
+ *
+ *   1. Explicit deployment.environment[.name] → use as-is
+ *   2. EKS / K8s → "eks:<cluster>/<namespace>" or "k8s:<cluster>/<namespace>"
+ *   3. ECS → "ecs:<cluster>"
+ *   4. EC2 (host is actually EC2) → "ec2:<asg>" when an ASG is known, else "ec2:default"
+ *   5. Otherwise (non-AWS / undetected host) → "generic:default"
+ *
+ * The EC2 branch is gated on the host actually being EC2, mirroring the CloudWatch agent,
+ * whose environment branches only run for EC2 (Platform == ModeEC2) or Kubernetes. On a
+ * non-AWS / non-K8s host the CloudWatch agent runs its "generic" resolver (Mode == onPremise)
+ * and emits "generic:default" — it never leaves Environment empty — so the SDK matches by
+ * returning "generic:default" rather than empty. (Verified live: blocking IMDS makes the agent
+ * fall to the generic resolver / "generic:default".)
+ *
+ * This enables the SDK to compute the same environment value the agent would, without
+ * depending on the agent process — an SDK-only alternative for deployment scenarios
+ * where the CloudWatch agent is not available or doesn't run the environment resolver.
+ */
+
+const AWS_LOCAL_ENVIRONMENT_KEY = 'aws.local.environment';
+
+export interface EnvironmentResolverInput {
+  /** All resource attributes as a flat key→value record (from Resource.attributes). */
+  attributes: Record<string, unknown>;
+}
+
+/**
+ * Resolve `aws.local.environment` from the given resource attributes.
+ * Returns the resolved value, or undefined if insufficient inputs are available.
+ */
+export function resolveLocalEnvironment(input: EnvironmentResolverInput): string {
+  const attrs = input.attributes;
+
+  // 1. Explicit deployment.environment[.name] wins outright.
+  const explicitEnv = asString(attrs['deployment.environment.name']) || asString(attrs['deployment.environment']);
+  if (explicitEnv) {
+    return explicitEnv;
+  }
+
+  // 2. Kubernetes (EKS / K8s): compose from platform + cluster + namespace.
+  const k8sClusterName = asString(attrs['k8s.cluster.name']);
+  const namespace = asString(attrs['k8s.namespace.name']);
+  const cloudPlatform = asString(attrs['cloud.platform']);
+
+  if (k8sClusterName) {
+    const ns = namespace || 'UnknownNamespace';
+    // cloud.platform = "aws_eks" → eks prefix; otherwise generic k8s.
+    const prefix = cloudPlatform === 'aws_eks' ? 'eks' : 'k8s';
+    return `${prefix}:${k8sClusterName}/${ns}`;
+  }
+
+  // 3. ECS: ecs:<clusterName>. The cluster name is the last segment of the ECS
+  //    cluster ARN (aws.ecs.cluster.arn), which the OTel awsEcsDetector emits.
+  //    Matches the agent's ecs.go resolver precedence (cluster → ecs:<cluster>).
+  const ecsClusterArn = asString(attrs['aws.ecs.cluster.arn']);
+  if (ecsClusterArn) {
+    const ecsCluster = ecsClusterArn.split('/').pop() || '';
+    if (ecsCluster) {
+      return `ecs:${ecsCluster}`;
+    }
+  }
+
+  // 4. EC2: only when the host is actually EC2 (matches the agent's Platform == ModeEC2
+  //    gate). Signals: cloud.platform=aws_ec2, host.id (EC2 instance id from the OTel EC2
+  //    detector), or the ASG tag (an IMDS-only EC2 signal).
+  const asg = asString(attrs['ec2.tag.aws:autoscaling:groupName']);
+  const isEc2 = cloudPlatform === 'aws_ec2' || !!asString(attrs['host.id']) || !!asg;
+  if (isEc2) {
+    return asg ? `ec2:${asg}` : 'ec2:default';
+  }
+
+  // 5. Non-AWS / undetected host: the CloudWatch agent runs its "generic" resolver here and
+  //    emits "generic:default" (never empty), so mirror that instead of omitting the key.
+  return 'generic:default';
+}
+
+/**
+ * Stamps `aws.local.environment` onto a mutable resource-attributes record, using
+ * the same resolution as the agent. Idempotent: if the attribute is already set
+ * (e.g. from a prior agent pass-through), it is left unchanged.
+ */
+export function stampLocalEnvironment(attrs: Record<string, string>): void {
+  if (attrs[AWS_LOCAL_ENVIRONMENT_KEY]) {
+    return;
+  }
+  // The resolver always yields a non-empty value (a platform scope, an explicit env, or the
+  // "generic:default" fallback), matching the CloudWatch agent, which always sets Environment.
+  const resolved = resolveLocalEnvironment({ attributes: attrs });
+  if (resolved) {
+    attrs[AWS_LOCAL_ENVIRONMENT_KEY] = resolved;
+  }
+}
+
+function asString(v: unknown): string {
+  if (typeof v === 'string' && v !== '') return v;
+  return '';
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/environment-resolver.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/utils/environment-resolver.ts
@@ -25,18 +25,12 @@
 
 const AWS_LOCAL_ENVIRONMENT_KEY = 'aws.local.environment';
 
-export interface EnvironmentResolverInput {
-  /** All resource attributes as a flat key→value record (from Resource.attributes). */
-  attributes: Record<string, unknown>;
-}
-
 /**
- * Resolve `aws.local.environment` from the given resource attributes.
- * Returns the resolved value, or undefined if insufficient inputs are available.
+ * Resolve `aws.local.environment` from the given resource attributes (a flat key→value
+ * record, e.g. from `Resource.attributes`). Always returns a non-empty value — a platform
+ * scope, an explicit env, or the `generic:default` fallback.
  */
-export function resolveLocalEnvironment(input: EnvironmentResolverInput): string {
-  const attrs = input.attributes;
-
+export function resolveLocalEnvironment(attrs: Record<string, unknown>): string {
   // 1. Explicit deployment.environment[.name] wins outright.
   const explicitEnv = asString(attrs['deployment.environment.name']) || asString(attrs['deployment.environment']);
   if (explicitEnv) {
@@ -91,7 +85,7 @@ export function stampLocalEnvironment(attrs: Record<string, string>): void {
   }
   // The resolver always yields a non-empty value (a platform scope, an explicit env, or the
   // "generic:default" fallback), matching the CloudWatch agent, which always sets Environment.
-  const resolved = resolveLocalEnvironment({ attributes: attrs });
+  const resolved = resolveLocalEnvironment(attrs);
   if (resolved) {
     attrs[AWS_LOCAL_ENVIRONMENT_KEY] = resolved;
   }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/client.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/client.test.ts
@@ -66,6 +66,50 @@ describe('DynamicInstrumentationClient', function () {
       scope.done();
     });
 
+    it('sends X-Aws-K8s-Namespace and X-Aws-Deployment-Environment headers when set', async function () {
+      let nsHeader: string | undefined;
+      let envHeader: string | undefined;
+      const scope = nock(API_HOST)
+        .post(LIST_PATH)
+        .reply(function () {
+          nsHeader = this.req.headers['x-aws-k8s-namespace'] as string | undefined;
+          envHeader = this.req.headers['x-aws-deployment-environment'] as string | undefined;
+          return [
+            200,
+            { Changed: false, SyncedAt: null, SyncInterval: null, LatestConfigurations: [], NextToken: null },
+          ];
+        });
+
+      const client = new DynamicInstrumentationClient(API_HOST, undefined, 'default', 'sample-env');
+      await client.fetchConfigurations('svc', 'sample-env', InstrumentationType.BREAKPOINT);
+
+      expect(nsHeader).toBe('default');
+      expect(envHeader).toBe('sample-env');
+      scope.done();
+    });
+
+    it('omits the environment headers when namespace/environment are empty', async function () {
+      let nsHeader: string | undefined;
+      let envHeader: string | undefined;
+      const scope = nock(API_HOST)
+        .post(LIST_PATH)
+        .reply(function () {
+          nsHeader = this.req.headers['x-aws-k8s-namespace'] as string | undefined;
+          envHeader = this.req.headers['x-aws-deployment-environment'] as string | undefined;
+          return [
+            200,
+            { Changed: false, SyncedAt: null, SyncInterval: null, LatestConfigurations: [], NextToken: null },
+          ];
+        });
+
+      const client = new DynamicInstrumentationClient(API_HOST);
+      await client.fetchConfigurations('svc', '', InstrumentationType.BREAKPOINT);
+
+      expect(nsHeader).toBeUndefined();
+      expect(envHeader).toBeUndefined();
+      scope.done();
+    });
+
     it('includes SyncedAt when lastSyncTime is provided', async function () {
       let captured: Record<string, unknown> = {};
       const scope = nock(API_HOST)

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/config.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/config.test.ts
@@ -112,6 +112,20 @@ describe('DynamicInstrumentationConfig', function () {
     expect(config.environment).toBe('prod');
   });
 
+  it('should resolve namespace from OTEL_RESOURCE_ATTRIBUTES[k8s.namespace.name]', function () {
+    clearDIEnvVars();
+    process.env.OTEL_RESOURCE_ATTRIBUTES = 'service.name=svc,k8s.namespace.name=team-a,other=val';
+    const config = createDynamicInstrumentationConfig();
+    expect(config.namespace).toBe('team-a');
+  });
+
+  it('should default namespace to empty when k8s.namespace.name is absent', function () {
+    clearDIEnvVars();
+    process.env.OTEL_RESOURCE_ATTRIBUTES = 'service.name=svc';
+    const config = createDynamicInstrumentationConfig();
+    expect(config.namespace).toBe('');
+  });
+
   it('should default service name to unknown_service', function () {
     clearDIEnvVars();
     delete process.env.OTEL_SERVICE_NAME;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/configuration-poller.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/configuration-poller.test.ts
@@ -27,6 +27,7 @@ function makeConfig(overrides: Partial<DynamicInstrumentationConfig> = {}): Dyna
     logsEndpoint: 'http://localhost:4316/v1/logs',
     serviceName: 'order-service',
     environment: 'production',
+    namespace: '',
     resourceAttributes: {
       'service.name': 'order-service',
       'deployment.environment.name': 'production',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/snapshot-collector-depth.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/snapshot-collector-depth.test.ts
@@ -33,6 +33,7 @@ describe('SnapshotCollector depth limits', function () {
       enabled: true,
       serviceName: 'test-service',
       environment: 'test',
+      namespace: '',
       apiUrl: 'http://localhost:4321',
       logsEndpoint: 'http://localhost:4321/v1/logs',
       probePollIntervalSeconds: 60,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/snapshot-collector-scopes.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/snapshot-collector-scopes.test.ts
@@ -34,6 +34,7 @@ describe('SnapshotCollector scope chain', function () {
       enabled: true,
       serviceName: 'test-service',
       environment: 'test',
+      namespace: '',
       apiUrl: 'http://localhost:4321',
       logsEndpoint: 'http://localhost:4321/v1/logs',
       probePollIntervalSeconds: 60,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/snapshot-trace-context.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/snapshot-trace-context.test.ts
@@ -29,6 +29,7 @@ describe('SnapshotCollector trace context extraction', function () {
       enabled: true,
       serviceName: 'test-service',
       environment: 'test',
+      namespace: '',
       apiUrl: 'http://localhost:4321',
       logsEndpoint: 'http://localhost:4321/v1/logs',
       probePollIntervalSeconds: 60,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/collectors/deployment-event-collector.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/collectors/deployment-event-collector.test.ts
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as assert from 'assert';
+import { DeploymentEventCollector } from '../../../src/serviceevents/collectors/deployment-event-collector';
+
+/**
+ * Fake emitter capturing emitDeploymentEvent triggers and exposing a controllable whenReady().
+ * Mirrors the real ServiceEventsOtlpEmitter contract used by the collector.
+ */
+class FakeEmitter {
+  triggers: string[] = [];
+  private resolveReady!: () => void;
+  private readyPromise: Promise<void>;
+
+  constructor(readyImmediately: boolean = false) {
+    this.readyPromise = new Promise<void>(resolve => {
+      this.resolveReady = resolve;
+    });
+    if (readyImmediately) this.resolveReady();
+  }
+
+  markReady(): void {
+    this.resolveReady();
+  }
+
+  whenReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  emitDeploymentEvent(trigger: string = 'periodic'): void {
+    this.triggers.push(trigger);
+  }
+}
+
+describe('DeploymentEventCollector', () => {
+  it('defers the startup emit until the emitter is ready (does NOT emit synchronously)', async () => {
+    const emitter = new FakeEmitter(/* readyImmediately */ false);
+    const collector = new DeploymentEventCollector(86_400_000, emitter as any);
+
+    collector.start();
+    // Synchronous: nothing emitted yet because the emitter isn't ready (the original bug —
+    // a synchronous startup emit here was dropped by ensureInitialized()'s readiness gate).
+    assert.deepStrictEqual(emitter.triggers, []);
+
+    emitter.markReady();
+    await emitter.whenReady();
+    // microtask flush for the .then() callback
+    await Promise.resolve();
+
+    assert.deepStrictEqual(emitter.triggers, ['startup']);
+    collector.stop();
+  });
+
+  it('emits startup exactly once even if start() resolves after readiness was already set', async () => {
+    const emitter = new FakeEmitter(/* readyImmediately */ true);
+    const collector = new DeploymentEventCollector(86_400_000, emitter as any);
+
+    collector.start();
+    await emitter.whenReady();
+    await Promise.resolve();
+
+    assert.deepStrictEqual(emitter.triggers, ['startup']);
+    collector.stop();
+  });
+
+  it('falls back to labeling the first collect "startup" if it runs before the deferred emit', () => {
+    // Simulate a collect() firing before whenReady() resolved (e.g. immediate shutdown).
+    const emitter = new FakeEmitter(/* readyImmediately */ false);
+    const collector = new DeploymentEventCollector(86_400_000, emitter as any);
+
+    // Do not call start() (so the deferred emit hasn't fired); invoke collect() directly.
+    (collector as any).collect();
+    assert.deepStrictEqual(emitter.triggers, ['startup']);
+  });
+
+  it('does not double-emit startup (deferred + fallback are mutually exclusive)', async () => {
+    const emitter = new FakeEmitter(/* readyImmediately */ true);
+    const collector = new DeploymentEventCollector(86_400_000, emitter as any);
+
+    collector.start();
+    await emitter.whenReady();
+    await Promise.resolve();
+    // A subsequent collect() must be 'periodic', not a second 'startup'.
+    (collector as any).collect();
+
+    assert.deepStrictEqual(emitter.triggers, ['startup', 'periodic']);
+    collector.stop();
+  });
+});

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/exporter/otlp-emitter.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/exporter/otlp-emitter.test.ts
@@ -7,6 +7,7 @@ import { EndpointMetricEvent, EndpointErrorMetric } from '../../../src/serviceev
 import { FunctionCallMetrics } from '../../../src/serviceevents/models/function-telemetry';
 import { IncidentSnapshot } from '../../../src/serviceevents/models/incident-telemetry';
 import { DeploymentContext } from '../../../src/serviceevents/models/deployment-telemetry';
+import { ResourceAttributes } from '../../../src/serviceevents/models/resource-attributes';
 import { OTLPAwsLogExporter } from '../../../src/exporter/otlp/aws/logs/otlp-aws-log-exporter';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
 import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
@@ -681,5 +682,107 @@ describe('ServiceEventsOtlpEmitter resource attributes', function () {
     const attrs = resourceAttrsOf(makeEmitter()); // no environment → key absent
     expect(attrs['deployment.environment']).toBeUndefined();
     expect(attrs['deployment.environment.name']).toBeUndefined();
+  });
+
+  it('folds detected cloud/k8s resource attributes (e.g. k8s.namespace.name) onto the resource', function () {
+    // The CloudWatch agent's Application Signals resolver builds aws.local.environment
+    // as `eks:<cluster>/<namespace>` from these resource attributes. Without them the
+    // resolver falls back to `UnknownNamespace`, breaking correlation with App Signals.
+    const resourceAttributes = new ResourceAttributes({
+      k8s_namespace_name: 'default',
+      k8s_cluster_name: 'my-cluster',
+      cloud_provider: 'aws',
+    });
+    const attrs = resourceAttrsOf(makeEmitter({ resourceAttributes }));
+    expect(attrs['k8s.namespace.name']).toBe('default');
+    expect(attrs['k8s.cluster.name']).toBe('my-cluster');
+    expect(attrs['cloud.provider']).toBe('aws');
+  });
+
+  it('lets a customer-set deployment.environment(.name) win over detected attributes (backwards compatible)', function () {
+    // Backwards compatibility: when the customer sets deployment.environment[.name]
+    // explicitly (carried via `environment`), it must still be respected even with
+    // detected resource attributes present. The explicit attrs merge LAST, so they win.
+    const resourceAttributes = new ResourceAttributes({ k8s_namespace_name: 'default' });
+    const attrs = resourceAttrsOf(makeEmitter({ environment: 'sample-env', resourceAttributes }));
+    expect(attrs['deployment.environment']).toBe('sample-env');
+    expect(attrs['deployment.environment.name']).toBe('sample-env');
+    // Detected attributes still ride along.
+    expect(attrs['k8s.namespace.name']).toBe('default');
+  });
+
+  it('works when no resourceAttributes are provided (unchanged pre-fix behavior)', function () {
+    // Defaults to an empty ResourceAttributes; no cloud/k8s keys appear, and the
+    // existing resource shape is otherwise unchanged.
+    const attrs = resourceAttrsOf(makeEmitter({ environment: 'prod' }));
+    expect(attrs['deployment.environment']).toBe('prod');
+    expect(attrs['k8s.namespace.name']).toBeUndefined();
+  });
+
+  it('awaits the detected resource async attributes before resolving aws.local.environment', async function () {
+    // Regression test for the JS async-detector race: the AWS resource detectors (ECS/EC2)
+    // are async, so a live Resource starts with asyncAttributesPending=true and its async
+    // attributes (e.g. aws.ecs.cluster.arn) are absent from `.attributes` until
+    // waitForAsyncAttributes() resolves. Before the fix, the emitter snapshotted too early
+    // and resolved ec2:default. Now it defers init until the async attrs settle.
+    let resolveAsync: () => void = () => {};
+    const asyncDone = new Promise<void>(r => (resolveAsync = r));
+    const detectedResource = {
+      // Sync attrs available immediately; the ECS cluster arn arrives only after await.
+      attributes: { 'cloud.platform': 'aws_ecs' } as Record<string, unknown>,
+      asyncAttributesPending: true,
+      waitForAsyncAttributes: () => asyncDone,
+    };
+    const emitter = makeEmitter({ detectedResource });
+
+    // Before async attrs settle, the emitter is gated (not ready) and an emit cannot init.
+    expect((emitter as any).asyncResourceReady).toBe(false);
+    emitter.emitEndpointSummary(makeEndpointEvent());
+    expect((emitter as any).loggerProvider).toBeFalsy(); // not initialized (null/undefined)
+
+    // Async detector now settles, adding the ECS cluster arn.
+    detectedResource.attributes['aws.ecs.cluster.arn'] = 'arn:aws:ecs:us-west-2:1:cluster/my-ecs';
+    resolveAsync();
+    await asyncDone;
+    await new Promise(r => setImmediate(r)); // let the .finally() flip asyncResourceReady
+    expect((emitter as any).asyncResourceReady).toBe(true);
+
+    const attrs = resourceAttrsOf(emitter); // emits again → now initializes
+    expect(attrs['aws.ecs.cluster.arn']).toBe('arn:aws:ecs:us-west-2:1:cluster/my-ecs');
+    expect(attrs['aws.local.environment']).toBe('ecs:my-ecs');
+  });
+
+  it('initializes after the timeout even if a detector never resolves (no permanent gate)', async function () {
+    // SAFETY regression: a hung/blocked detector (e.g. IMDS unreachable on EC2) must NOT
+    // permanently disable ServiceEvents. waitForAsyncAttributes() that never settles should
+    // be overridden by the internal timeout, after which the emitter initializes with
+    // whatever attributes resolved synchronously.
+    const neverResolves = new Promise<void>(() => {}); // intentionally never settles
+    const detectedResource = {
+      attributes: { 'cloud.platform': 'aws_ec2' } as Record<string, unknown>,
+      asyncAttributesPending: true,
+      waitForAsyncAttributes: () => neverResolves,
+    };
+    const emitter = makeEmitter({ detectedResource });
+    expect((emitter as any).asyncResourceReady).toBe(false);
+
+    // Wait past the 2s internal timeout.
+    await new Promise(r => setTimeout(r, 2300));
+    expect((emitter as any).asyncResourceReady).toBe(true);
+
+    const attrs = resourceAttrsOf(emitter); // emits → initializes with sync attrs
+    // EC2 with no ASG resolved → ec2:default (the resolver fallback), NOT stuck/no-output.
+    expect(attrs['aws.local.environment']).toBe('ec2:default');
+  });
+
+  it('does not defer when the detected resource has no pending async attributes', function () {
+    // A resource with asyncAttributesPending=false (or absent) must initialize on first
+    // emit, unchanged — the gate only applies to genuinely-pending async resources.
+    const detectedResource = {
+      attributes: { 'cloud.platform': 'aws_ecs', 'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:1:cluster/c' },
+      asyncAttributesPending: false,
+    };
+    const attrs = resourceAttrsOf(makeEmitter({ detectedResource }));
+    expect(attrs['aws.local.environment']).toBe('ecs:c');
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/ec2-asg-detector.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/ec2-asg-detector.test.ts
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import expect from 'expect';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { Ec2AutoScalingGroupDetector, EC2_ASG_ATTRIBUTE } from '../../../src/serviceevents/utils/ec2-asg-detector';
+
+/**
+ * The custom EC2 ASG detector fetches aws:autoscaling:groupName from IMDS instance
+ * tags (the stock OTel awsEc2Detector does not), so the SDK resource carries the same
+ * ASG the CloudWatch agent uses to resolve ec2:<asg>.
+ */
+describe('Ec2AutoScalingGroupDetector', function () {
+  let server: http.Server;
+  let host: string;
+
+  function startImds(handler: (req: http.IncomingMessage, res: http.ServerResponse) => void, done: () => void) {
+    server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      host = `127.0.0.1:${port}`;
+      done();
+    });
+  }
+
+  afterEach(function (done: Mocha.Done) {
+    if (server) server.close(() => done());
+    else done();
+  });
+
+  // Resolve the (possibly Promise) attribute value the detector returns.
+  async function detectAsg(): Promise<unknown> {
+    const detector = new Ec2AutoScalingGroupDetector(host);
+    const detected = detector.detect();
+    return await (detected.attributes?.[EC2_ASG_ATTRIBUTE] as Promise<unknown>);
+  }
+
+  it('fetches the ASG from IMDS instance tags (token + tag value)', function (done: Mocha.Done) {
+    startImds(
+      (req, res) => {
+        if (req.method === 'PUT' && req.url === '/latest/api/token') {
+          res.writeHead(200);
+          res.end('fake-token');
+        } else if (req.url === '/latest/meta-data/tags/instance/aws:autoscaling:groupName') {
+          expect(req.headers['x-aws-ec2-metadata-token']).toBe('fake-token');
+          res.writeHead(200);
+          res.end('my-asg');
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      },
+      async () => {
+        const asg = await detectAsg();
+        expect(asg).toBe('my-asg');
+        done();
+      }
+    );
+  });
+
+  it('returns undefined when instance tags are not enabled (404 on tag path)', function (done: Mocha.Done) {
+    startImds(
+      (req, res) => {
+        if (req.method === 'PUT' && req.url === '/latest/api/token') {
+          res.writeHead(200);
+          res.end('fake-token');
+        } else {
+          res.writeHead(404); // instance metadata tags disabled
+          res.end();
+        }
+      },
+      async () => {
+        const asg = await detectAsg();
+        expect(asg).toBeUndefined();
+        done();
+      }
+    );
+  });
+
+  it('returns undefined when not on EC2 (token endpoint unreachable)', async function () {
+    // Point at a closed port — connection refused, mimicking "not on EC2".
+    const detector = new Ec2AutoScalingGroupDetector('127.0.0.1:1');
+    const detected = detector.detect();
+    const asg = await (detected.attributes?.[EC2_ASG_ATTRIBUTE] as Promise<unknown>);
+    expect(asg).toBeUndefined();
+  });
+});

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/ecs-cluster-detector.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/ecs-cluster-detector.test.ts
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import expect from 'expect';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { EcsClusterDetector } from '../../../src/serviceevents/utils/ecs-cluster-detector';
+
+/**
+ * The EcsClusterDetector reads the ECS task metadata endpoint and emits aws.ecs.cluster.arn
+ * (+ cloud.platform=aws_ecs) as PER-KEY promises — working around the upstream AwsEcsDetector
+ * which returns attributes as a single Promise that ResourceImpl drops.
+ */
+describe('EcsClusterDetector', function () {
+  let server: http.Server;
+  let baseUri: string;
+
+  function startMetadata(handler: http.RequestListener, done: () => void) {
+    server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      baseUri = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      done();
+    });
+  }
+
+  afterEach(function (done: Mocha.Done) {
+    if (server) server.close(() => done());
+    else done();
+  });
+
+  async function detectArn(uri: string): Promise<unknown> {
+    const detected = new EcsClusterDetector(uri).detect();
+    return await (detected.attributes?.['aws.ecs.cluster.arn'] as Promise<unknown>);
+  }
+
+  it('derives the cluster ARN from the task ARN when Cluster is a bare name', function (done: Mocha.Done) {
+    startMetadata(
+      (req, res) => {
+        if (req.url === '/task') {
+          res.writeHead(200);
+          res.end(
+            JSON.stringify({
+              Cluster: 'my-ecs',
+              TaskARN: 'arn:aws:ecs:us-west-2:123456789012:task/my-ecs/abcdef',
+            })
+          );
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      },
+      async () => {
+        const arn = await detectArn(baseUri);
+        expect(arn).toBe('arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs');
+        done();
+      }
+    );
+  });
+
+  it('uses Cluster directly when it is already a full ARN', function (done: Mocha.Done) {
+    startMetadata(
+      (req, res) => {
+        res.writeHead(200);
+        res.end(
+          JSON.stringify({
+            Cluster: 'arn:aws:ecs:us-west-2:1:cluster/already-arn',
+            TaskARN: 'arn:aws:ecs:us-west-2:1:task/already-arn/x',
+          })
+        );
+      },
+      async () => {
+        expect(await detectArn(baseUri)).toBe('arn:aws:ecs:us-west-2:1:cluster/already-arn');
+        done();
+      }
+    );
+  });
+
+  it('sets cloud.platform=aws_ecs only when a cluster resolved', function (done: Mocha.Done) {
+    startMetadata(
+      (req, res) => {
+        res.writeHead(200);
+        res.end(JSON.stringify({ Cluster: 'c', TaskARN: 'arn:aws:ecs:us-west-2:1:task/c/x' }));
+      },
+      async () => {
+        const detected = new EcsClusterDetector(baseUri).detect();
+        expect(await (detected.attributes?.['cloud.platform'] as Promise<unknown>)).toBe('aws_ecs');
+        done();
+      }
+    );
+  });
+
+  it('contributes nothing when not on ECS (no metadata URI)', async function () {
+    const detected = new EcsClusterDetector(undefined).detect();
+    expect(Object.keys(detected.attributes ?? {})).toHaveLength(0);
+  });
+
+  it('resolves undefined when the metadata endpoint is unreachable', async function () {
+    // Closed port → connection refused.
+    const arn = await detectArn('http://127.0.0.1:1');
+    expect(arn).toBeUndefined();
+  });
+});

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/environment-resolver.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/environment-resolver.test.ts
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import expect from 'expect';
+import { resolveLocalEnvironment, stampLocalEnvironment } from '../../../src/serviceevents/utils/environment-resolver';
+
+/**
+ * The SDK-side resolver must produce the SAME aws.local.environment the CloudWatch
+ * agent's awsapplicationsignals resolver produces, from the same OTel resource attributes.
+ * Precedence: explicit deployment.environment[.name] → eks/k8s cluster/namespace →
+ * ec2 ASG → ec2:default.
+ */
+describe('environment-resolver', function () {
+  describe('resolveLocalEnvironment()', function () {
+    it('explicit deployment.environment.name wins over everything', function () {
+      expect(
+        resolveLocalEnvironment({
+          attributes: {
+            'deployment.environment.name': 'my-env',
+            'k8s.cluster.name': 'c',
+            'k8s.namespace.name': 'ns',
+            'cloud.platform': 'aws_eks',
+            'ec2.tag.aws:autoscaling:groupName': 'asg',
+          },
+        })
+      ).toBe('my-env');
+    });
+
+    it('legacy deployment.environment is honored', function () {
+      expect(resolveLocalEnvironment({ attributes: { 'deployment.environment': 'legacy-env' } })).toBe('legacy-env');
+    });
+
+    it('EKS → eks:<cluster>/<namespace>', function () {
+      expect(
+        resolveLocalEnvironment({
+          attributes: {
+            'cloud.platform': 'aws_eks',
+            'k8s.cluster.name': 'my-cluster',
+            'k8s.namespace.name': 'default',
+          },
+        })
+      ).toBe('eks:my-cluster/default');
+    });
+
+    it('EKS with missing namespace → UnknownNamespace', function () {
+      expect(
+        resolveLocalEnvironment({ attributes: { 'cloud.platform': 'aws_eks', 'k8s.cluster.name': 'my-cluster' } })
+      ).toBe('eks:my-cluster/UnknownNamespace');
+    });
+
+    it('non-EKS Kubernetes → k8s:<cluster>/<namespace>', function () {
+      expect(resolveLocalEnvironment({ attributes: { 'k8s.cluster.name': 'c', 'k8s.namespace.name': 'team-a' } })).toBe(
+        'k8s:c/team-a'
+      );
+    });
+
+    it('ECS → ecs:<cluster> (cluster name from aws.ecs.cluster.arn)', function () {
+      expect(
+        resolveLocalEnvironment({
+          attributes: {
+            'cloud.platform': 'aws_ecs',
+            'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster',
+          },
+        })
+      ).toBe('ecs:my-ecs-cluster');
+    });
+
+    it('explicit environment still wins over ECS cluster', function () {
+      expect(
+        resolveLocalEnvironment({
+          attributes: {
+            'deployment.environment.name': 'prod',
+            'cloud.platform': 'aws_ecs',
+            'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster',
+          },
+        })
+      ).toBe('prod');
+    });
+
+    it('EC2 with ASG → ec2:<asg>', function () {
+      expect(resolveLocalEnvironment({ attributes: { 'ec2.tag.aws:autoscaling:groupName': 'my-asg' } })).toBe(
+        'ec2:my-asg'
+      );
+    });
+
+    it('EC2 without ASG → ec2:default', function () {
+      expect(resolveLocalEnvironment({ attributes: { 'cloud.platform': 'aws_ec2' } })).toBe('ec2:default');
+    });
+
+    it('empty attributes (non-AWS / undetected host) → "generic:default" (matches agent generic resolver)', function () {
+      expect(resolveLocalEnvironment({ attributes: {} })).toBe('generic:default');
+    });
+
+    it('non-AWS host with only service.name/host.name → "generic:default"', function () {
+      expect(resolveLocalEnvironment({ attributes: { 'service.name': 'svc', 'host.name': 'my-vm' } })).toBe(
+        'generic:default'
+      );
+    });
+
+    it('EC2 detected via host.id → ec2:default', function () {
+      expect(resolveLocalEnvironment({ attributes: { 'cloud.platform': 'aws_ec2', 'host.id': 'i-0abc' } })).toBe(
+        'ec2:default'
+      );
+    });
+
+    it('stampLocalEnvironment stamps generic:default on a non-AWS host', function () {
+      const attrs: Record<string, string> = { 'service.name': 'svc' };
+      stampLocalEnvironment(attrs);
+      expect(attrs['aws.local.environment']).toBe('generic:default');
+    });
+  });
+
+  describe('stampLocalEnvironment()', function () {
+    it('stamps aws.local.environment from the resolved value', function () {
+      const attrs: Record<string, string> = {
+        'cloud.platform': 'aws_eks',
+        'k8s.cluster.name': 'my-cluster',
+        'k8s.namespace.name': 'default',
+      };
+      stampLocalEnvironment(attrs);
+      expect(attrs['aws.local.environment']).toBe('eks:my-cluster/default');
+    });
+
+    it('does not overwrite an existing aws.local.environment', function () {
+      const attrs: Record<string, string> = {
+        'aws.local.environment': 'already-set',
+        'k8s.cluster.name': 'c',
+        'k8s.namespace.name': 'ns',
+        'cloud.platform': 'aws_eks',
+      };
+      stampLocalEnvironment(attrs);
+      expect(attrs['aws.local.environment']).toBe('already-set');
+    });
+  });
+});

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/environment-resolver.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/utils/environment-resolver.test.ts
@@ -15,52 +15,44 @@ describe('environment-resolver', function () {
     it('explicit deployment.environment.name wins over everything', function () {
       expect(
         resolveLocalEnvironment({
-          attributes: {
-            'deployment.environment.name': 'my-env',
-            'k8s.cluster.name': 'c',
-            'k8s.namespace.name': 'ns',
-            'cloud.platform': 'aws_eks',
-            'ec2.tag.aws:autoscaling:groupName': 'asg',
-          },
+          'deployment.environment.name': 'my-env',
+          'k8s.cluster.name': 'c',
+          'k8s.namespace.name': 'ns',
+          'cloud.platform': 'aws_eks',
+          'ec2.tag.aws:autoscaling:groupName': 'asg',
         })
       ).toBe('my-env');
     });
 
     it('legacy deployment.environment is honored', function () {
-      expect(resolveLocalEnvironment({ attributes: { 'deployment.environment': 'legacy-env' } })).toBe('legacy-env');
+      expect(resolveLocalEnvironment({ 'deployment.environment': 'legacy-env' })).toBe('legacy-env');
     });
 
     it('EKS → eks:<cluster>/<namespace>', function () {
       expect(
         resolveLocalEnvironment({
-          attributes: {
-            'cloud.platform': 'aws_eks',
-            'k8s.cluster.name': 'my-cluster',
-            'k8s.namespace.name': 'default',
-          },
+          'cloud.platform': 'aws_eks',
+          'k8s.cluster.name': 'my-cluster',
+          'k8s.namespace.name': 'default',
         })
       ).toBe('eks:my-cluster/default');
     });
 
     it('EKS with missing namespace → UnknownNamespace', function () {
-      expect(
-        resolveLocalEnvironment({ attributes: { 'cloud.platform': 'aws_eks', 'k8s.cluster.name': 'my-cluster' } })
-      ).toBe('eks:my-cluster/UnknownNamespace');
+      expect(resolveLocalEnvironment({ 'cloud.platform': 'aws_eks', 'k8s.cluster.name': 'my-cluster' })).toBe(
+        'eks:my-cluster/UnknownNamespace'
+      );
     });
 
     it('non-EKS Kubernetes → k8s:<cluster>/<namespace>', function () {
-      expect(resolveLocalEnvironment({ attributes: { 'k8s.cluster.name': 'c', 'k8s.namespace.name': 'team-a' } })).toBe(
-        'k8s:c/team-a'
-      );
+      expect(resolveLocalEnvironment({ 'k8s.cluster.name': 'c', 'k8s.namespace.name': 'team-a' })).toBe('k8s:c/team-a');
     });
 
     it('ECS → ecs:<cluster> (cluster name from aws.ecs.cluster.arn)', function () {
       expect(
         resolveLocalEnvironment({
-          attributes: {
-            'cloud.platform': 'aws_ecs',
-            'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster',
-          },
+          'cloud.platform': 'aws_ecs',
+          'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster',
         })
       ).toBe('ecs:my-ecs-cluster');
     });
@@ -68,39 +60,31 @@ describe('environment-resolver', function () {
     it('explicit environment still wins over ECS cluster', function () {
       expect(
         resolveLocalEnvironment({
-          attributes: {
-            'deployment.environment.name': 'prod',
-            'cloud.platform': 'aws_ecs',
-            'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster',
-          },
+          'deployment.environment.name': 'prod',
+          'cloud.platform': 'aws_ecs',
+          'aws.ecs.cluster.arn': 'arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster',
         })
       ).toBe('prod');
     });
 
     it('EC2 with ASG → ec2:<asg>', function () {
-      expect(resolveLocalEnvironment({ attributes: { 'ec2.tag.aws:autoscaling:groupName': 'my-asg' } })).toBe(
-        'ec2:my-asg'
-      );
+      expect(resolveLocalEnvironment({ 'ec2.tag.aws:autoscaling:groupName': 'my-asg' })).toBe('ec2:my-asg');
     });
 
     it('EC2 without ASG → ec2:default', function () {
-      expect(resolveLocalEnvironment({ attributes: { 'cloud.platform': 'aws_ec2' } })).toBe('ec2:default');
+      expect(resolveLocalEnvironment({ 'cloud.platform': 'aws_ec2' })).toBe('ec2:default');
     });
 
     it('empty attributes (non-AWS / undetected host) → "generic:default" (matches agent generic resolver)', function () {
-      expect(resolveLocalEnvironment({ attributes: {} })).toBe('generic:default');
+      expect(resolveLocalEnvironment({})).toBe('generic:default');
     });
 
     it('non-AWS host with only service.name/host.name → "generic:default"', function () {
-      expect(resolveLocalEnvironment({ attributes: { 'service.name': 'svc', 'host.name': 'my-vm' } })).toBe(
-        'generic:default'
-      );
+      expect(resolveLocalEnvironment({ 'service.name': 'svc', 'host.name': 'my-vm' })).toBe('generic:default');
     });
 
     it('EC2 detected via host.id → ec2:default', function () {
-      expect(resolveLocalEnvironment({ attributes: { 'cloud.platform': 'aws_ec2', 'host.id': 'i-0abc' } })).toBe(
-        'ec2:default'
-      );
+      expect(resolveLocalEnvironment({ 'cloud.platform': 'aws_ec2', 'host.id': 'i-0abc' })).toBe('ec2:default');
     });
 
     it('stampLocalEnvironment stamps generic:default on a non-AWS host', function () {


### PR DESCRIPTION
Draft on my fork for self-review before opening upstream (aws-observability#503).

> ⚠️ **Diff shows 2 commits**: this fork's `main` is at `9e3d4c0`, while our branch was built on upstream `6b185d7` ("feat: support lite mode on ESM handlers and Node 24"). That lite-mode commit is **not ours** — it's just the upstream base. Fast-forwarding this fork's `main` to `6b185d7` makes the diff show only our single commit `13de1fa`:
> `git push origin 6b185d77e469f37ae6b1b1a764a91107d1d1a080:refs/heads/main`
> (The real upstream PR aws-observability#503 correctly shows **1 commit**, since it targets upstream `main`.)

## What
Resolve `aws.local.environment` in the ADOT JS SDK so ServiceEvents + Dynamic Instrumentation report
the same Environment that CloudWatch Agent / Application Signals resolves.

Precedence mirrors the agent's `awsapplicationsignals` resolver:
`deployment.environment[.name]` → `eks:<cluster>/<ns>` / `k8s:<cluster>/<ns>` → `ecs:<cluster>` → `ec2:<asg>` → `ec2:default` → `generic:default`.

## Key pieces
- `serviceevents/utils/environment-resolver.ts` — the resolver
- `serviceevents/utils/ec2-asg-detector.ts` — custom ASG detector (stock OTel EC2 detector omits the ASG tag; 1s IMDS timeout)
- `serviceevents/utils/ecs-cluster-detector.ts` — **JS-only workaround**: the upstream `AwsEcsDetector` returns attributes as a single Promise that `ResourceImpl` drops, so ECS attrs were missing and ECS resolved `ec2:default`. This detector reads the task metadata endpoint directly.
- `serviceevents/exporter/otlp-emitter.ts` — awaits the resource's async attributes (`waitForAsyncAttributes` raced with a 2s timeout) before snapshotting for resolution, since JS's AWS detectors are async (Java/Python are sync). Exposes `whenReady()`; `DeploymentEventCollector` defers its startup emit on it so the startup DeploymentEvent isn't silently dropped.
- non-AWS fix: emit `ec2:*` only on a real EC2 signal, else `generic:default`

## Validation (live, account 341705376693)
| Platform | SDK (SE/DI) | CWAgent (AppSignals) |
|---|---|---|
| EC2 default | `ec2:default` | `ec2:default` ✅ |
| EC2 + ASG | `ec2:adot-env-test-asg` | same ✅ |
| EKS | `eks:<cluster>/<ns>` | same ✅ |
| ECS | `ecs:<cluster>` | same ✅ (after the EcsClusterDetector fix) |
| native K8s (k3s) | `k8s:<cluster>/<ns>` | same ✅ |

Tests: 1719 passing; lint (prettier + eslint typedefs) clean.